### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/01-explore-ml.md
+++ b/Instructions/Labs/01-explore-ml.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Explore machine learning scenarios'
-    description: 'Explore applications that demonstrate how a machine learning model can help you predict unknown information.'
+  title: Explore machine learning scenarios
+  description: Explore applications that demonstrate how a machine learning model can help you predict unknown information.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Explore machine learning scenarios

--- a/Instructions/Labs/02-explore-ai-agent.md
+++ b/Instructions/Labs/02-explore-ai-agent.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Explore generative AI and agent scenarios'
-    description: 'Explore applications that demonstrate how Generative AI agents can reason over input and data, and generate intelligent responses.'
+  title: Explore generative AI and agent scenarios
+  description: Explore applications that demonstrate how Generative AI agents can reason over input and data, and generate intelligent responses.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Explore generative AI and agent scenarios

--- a/Instructions/Labs/03-explore-nlp.md
+++ b/Instructions/Labs/03-explore-nlp.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Explore natural language processing scenarios'
-    description: 'Explore applications that demonstrates how AI natural language processing capabilities can be used to transcribe and analyze spoken and written text.'
+  title: Explore natural language processing scenarios
+  description: Explore applications that demonstrates how AI natural language processing capabilities can be used to transcribe and analyze spoken and written text.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Explore natural language processing scenarios

--- a/Instructions/Labs/04-explore-vision.md
+++ b/Instructions/Labs/04-explore-vision.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Explore computer vision scenarios'
-    description: 'Explore a applications that demonstrates how AI computer vision capabilities can be used to analyze images, generate captions and tags, and detect objects.'
+  title: Explore computer vision scenarios
+  description: Explore a applications that demonstrates how AI computer vision capabilities can be used to analyze images, generate captions and tags, and detect objects.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Explore computer vision scenarios

--- a/Instructions/Labs/05-explore-info.md
+++ b/Instructions/Labs/05-explore-info.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Explore AI information extraction scenarios'
-    description: 'Explore applications that demonstrates how AI can be used to extract the information from content in multiple formats.'
+  title: Explore AI information extraction scenarios
+  description: Explore applications that demonstrates how AI can be used to extract the information from content in multiple formats.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Explore AI information extraction scenarios


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/01-explore-ml.md` (duration,level,islab)
- `Instructions/Labs/02-explore-ai-agent.md` (duration,level,islab)
- `Instructions/Labs/03-explore-nlp.md` (duration,level,islab)
- `Instructions/Labs/04-explore-vision.md` (duration,level,islab)
- `Instructions/Labs/05-explore-info.md` (duration,level,islab)
